### PR TITLE
pnfsToXRootD adopts new portal for XRootD

### DIFF
--- a/bin/pnfsToXRootD
+++ b/bin/pnfsToXRootD
@@ -125,7 +125,7 @@ function ConvertPNFStoXRootD() {
   # this pattern was tested on 20171208 on URLs from:
   # /pnfs/uboone
   # /pnfs/sbnd
-  echo "root://fndca1.fnal.gov:1094/pnfs/fnal.gov/usr${URL#/pnfs}"
+  echo "root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov/usr${URL#/pnfs}"
   
 } # ConvertPNFStoXRootD()
 


### PR DESCRIPTION
The URL produces by `pnfsToXRootD` will point to `fndcadoor.fnal.gov` instead of `fndca1.fnal.gov`.
Documentation: slide 6 of
https://indico.fnal.gov/event/58991/contributions/262585/attachments/164965/218998/FIFE_dCache_2023.pdf

As the documentation above says that change has been running "for sometime now", this should be ready to go in without disruption. 