### PR TITLE
Fixed pnfsToXRootD exit code

### DIFF
--- a/bin/pnfsToXRootD
+++ b/bin/pnfsToXRootD
@@ -166,6 +166,7 @@ function ConvertURLs() {
     [[ $res != 0 ]] && let ++nErrors
   done
   PrintSummary "$nURLS" "$nErrors"
+  [[ "$nErrors" == 0 ]]  # return value
 } # ConvertURLs()
 
 
@@ -180,6 +181,7 @@ function ConvertURLsFromSTDIN() {
     [[ $res != 0 ]] && let ++nErrors
   done
   PrintSummary "$nURLS" "$nErrors"
+  [[ "$nErrors" == 0 ]]  # return value
 } # ConvertURLsFromSTDIN()
 
 


### PR DESCRIPTION
`pnfsToXRootD` is a simple script heuristically converting a dCache POSIX path (`/path/...`) into a XRootD URL.

The exit code of this script was hijacked by a printout function, and happens to report failure on success and success in some failure modes. This patch should restore the correct exit code.

Recommending @vitodb review for this one (and also a review on the hard-coded dCache base URL, `root://fndcadoor.fnal.gov:1094/pnfs/fnal.gov`, would not be bad, to make sure it is still up to date).